### PR TITLE
Switch to a more robust approach to handling unexpected inputs

### DIFF
--- a/crates-io-to-lib-rs.user.js
+++ b/crates-io-to-lib-rs.user.js
@@ -1,18 +1,28 @@
 // ==UserScript==
 // @name         crates.io -> lib.rs
-// @version      0.1.2
+// @version      0.1.3
 // @license      GPL-3.0-only; http://www.gnu.org/licenses/gpl-3.0.txt
 // @homepageURL  https://github.com/Logarithmus/crates-io-to-lib-rs
-// @description  Replace all links to crates.io with ones to lib.rs, as the latter is much faster cause it doesn't use tons of javascript
+// @description  Replace all links to crates.io with ones to lib.rs, as the latter is much faster because it doesn't use tons of JavaScript
 // @author       Logarithmus
 // @match        *://*/*
 // ==/UserScript==
 
 (function() {
-    const regex = /(.*?\:\/\/)crates\.io(.*)/
+    let url = null;
     for (let a of document.getElementsByTagName("a")) {
-        if (a.hasAttribute("href")) {
-        	a.href = a.href.replace(regex, "$1lib.rs$2")
+        // Skip to next tag on "not a valid URL"
+        try {
+            // Rely on the browser's own URL parser for robustness
+            url = new URL(a.href);
+        } catch (e) {
+            continue;
+        }
+
+        // Only modify relevant <a> tags to avoid breaking sites
+        if (url.hostname === "crates.io") {
+          url.hostname = "lib.rs";
+          a.href = url.toString();
         }
     }
 })();


### PR DESCRIPTION
Here's the revised code I posted on Reddit.

I also corrected a couple of minor typos in the description.

Another thing that I'd like to add, if you're receptive to it, would be whitelisting for URLs that are known to match between the two sites.

Currently, the script breaks the following links on crates.io itself which lib.rs has no equivalent to:

* https://crates.io/policies
* https://crates.io/login
* https://crates.io/category_slugs
* https://crates.io/crates

The simplest solution would be to check that `url.pathname` either starts with `/crates/` or is one of `/` or an empty string before doing a rewrite.

(And sorry for taking longer than I said. I was just too tired to work on it last evening.)